### PR TITLE
Add doc dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,4 @@
 #lang info
 (define collection 'multi)
 (define deps '("grip" "typed-racket-lib" "base"))
-(define build-deps '("scribble-lib"))
+(define build-deps '("racket-doc" "typed-racket-doc" "scribble-lib"))


### PR DESCRIPTION
Build is reporting unreported dependencies on racket-doc and typed-racket-doc.