### PR TITLE
Update require line in documentation

### DIFF
--- a/grommet/scribblings/grommet.scrbl
+++ b/grommet/scribblings/grommet.scrbl
@@ -30,7 +30,7 @@ Base64 decode the given string to an array of bytes.
 Various cryptography hash functions.
 
 @subsection{MD5}
-@defmodule["crypto/hash/md5.rkt"]{
+@defmodule[grommet/crypto/hash/md5]{
 
 @deftogether[[
 @defproc[(md5-hex [array (U String Bytes Input-Port)]) Bytes]
@@ -50,7 +50,7 @@ Typed wrappers around the MD5 procedures in @tt{file/md5} in untyped Racket exce
 
 @subsection{SHA-1}
 
-@defmodule["crypto/hash/sha1.rkt"]{
+@defmodule[grommet/crypto/hash/sha1]{
 
 @defproc[(sha1-bytes [bytes Bytes]) Bytes]{
 Typed wrapper around sha1-bytes procedure provided by Racket's @tt{openssl/sha1}.
@@ -62,7 +62,7 @@ Typed wrapper around sha1-bytes procedure provided by Racket's @tt{openssl/sha1}
 
 Pure Typed Racket implementation of SHA-256.
 
-@defmodule["crypto/hash/sha256.rkt"]{
+@defmodule[gromment/hash/sha256]{
 
 @defproc[(sha256 [data (U Bytes String)]) Bytes]{
 Hash the given data using SHA-256 algorithm.
@@ -72,7 +72,7 @@ Hash the given data using SHA-256 algorithm.
 
 @section{HMAC}
 
-@defmodule["crypto/hmac.rkt"]{
+@defmodule[grommet/crypto/hmac]{
 
 @defproc[(hmac-sha256 [secret (U String Bytes)] [message (U Bytes String)]) Bytes]{
 Generates the an HMAC signature of the @racket{message} with the @racket{secret}.


### PR DESCRIPTION
I'm a first time Racketeer and I stumbled upon this potential issue while using `grommet`.

The documentation currently instructs users to use `(require "crypto/hash/sha256.rkt")` when requiring packages but the syntax should actually be `(require gromment/hash/sha256)`. I believe that this should make it easier for new users to utilize the library.

I don't believe this will break how the documentation is built (tested on local), but let me know if it does.