### PR TITLE
Fix module name in docs

### DIFF
--- a/grommet/scribblings/grommet.scrbl
+++ b/grommet/scribblings/grommet.scrbl
@@ -6,8 +6,6 @@
 
 @title[#:tag "top"]{@bold{Crypto} Typed Racket crypto procedures}
 
-@declare-exporting["../../crypto.rkt"]
-
 @table-of-contents[]
 
 by Ray Racine (@tt{ray dot racine at gmail dot com})
@@ -15,6 +13,8 @@ by Ray Racine (@tt{ray dot racine at gmail dot com})
 Provides a pure Typed Racket implementation of SHA-256 and typed wrappers for existing functions sucha as Base64 encoding, SHA-1 and MD-5.
 
 @section{Base64}
+
+@defmodule[grommet/crypto/base64]{
 
 Base64 encoding and decoding routines.
 
@@ -24,6 +24,8 @@ Base64 encode a byte array to a string.
 
 @defproc[(base64-decode [str String]) Bytes]{
 Base64 decode the given string to an array of bytes.			
+}
+
 }
 
 @section{Hash}


### PR DESCRIPTION
In the docs, the module of `base64-encode` and `base64-decode` appears as "../../crypto.rkt" instead of "grommet/crypto/base64".

This was reported by @endobson in https://github.com/racket/racket/issues/1426 (screenshot and more info there).
